### PR TITLE
Add Daily Refresh Workflow (Scheduled Job)

### DIFF
--- a/.github/workflows/daily_refresh.yml
+++ b/.github/workflows/daily_refresh.yml
@@ -1,0 +1,38 @@
+name: Daily Refresh (Production)
+
+on:
+  schedule:
+    - cron: '0 8 * * *' # Runs daily at 8am UTC
+
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    env:
+      DBT_USER: ${{ secrets.DBT_USER }}
+      DBT_PASSWORD: ${{ secrets.DBT_PASSWORD }}
+      DATABASE_HOST: ${{ secrets.DATABASE_HOST }}
+      DATABASE_PORT: ${{ secrets.DATABASE_PORT }}
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          
+      - name: Install dbt
+        run: pip install dbt-postgres
+
+      - name: Install dbt Packages
+        run: dbt deps
+
+      - name: Deploy & Test Models (dbt build)
+        run: > 
+          dbt build -s warehouse marts
+          --exclude dim_calendar_dates
+          --profiles-dir _project_docs/automation 
+          --target prod


### PR DESCRIPTION
### Summary:
This PR adds functionality to refresh `production` models on a consistent schedule.

### Details:
- Added a GitHub Actions workflow file for:
   - `daily_refresh.yml` - Automatically deploy & test `warehouse` & `marts` models in `prod` on a Cron schedule
- Does not refresh the following:
   - `staging` - These are `views`, meaning they do not store data and do not require a refresh.
   - `dim_calendar_dates` - This is static data that does not require a refresh. 
   - New logic changes for these would be implemented during the `post_merge_deploy` workflow.


**Links**:
- [Run Action on Cron Schedule](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule)
- [Create Cron Expression](https://crontab.guru/)
- [dbt Exclude](https://docs.getdbt.com/reference/node-selection/exclude)